### PR TITLE
Fixes issue #17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ endif
 
 
 # CXXFLAGS can be overridden by the user.
-CXXFLAGS    ?= -Wall -Wextra -pedantic -march=native
+CXXFLAGS    ?= -Wall -Wextra -pedantic -mtune=core2
 
 
 # These flags are required for the build to work.

--- a/unicycler/misc.py
+++ b/unicycler/misc.py
@@ -927,7 +927,7 @@ def java_path_and_version(java_path):
     out, _ = process.communicate()
 
     # more flexible version string
-    version = re.match(r'^.* version \'"([^\'"]+).*$', out.decode(), re.MULTILINE)
+    version = re.match(r'^.* version[ \'"]+([^ \'"]+).*$', out.decode(), re.MULTILINE)
     version = version.group(1) if version else ''
 
     # Make sure Java is 1.7+

--- a/unicycler/misc.py
+++ b/unicycler/misc.py
@@ -925,7 +925,10 @@ def java_path_and_version(java_path):
     command = [java_path, '-version']
     process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out, _ = process.communicate()
-    version = out.decode().split('java version ')[-1].split()[0].replace('"', '')
+
+    # more flexible version string
+    version = re.match(r'^.* version \'"([^\'"]+).*$', out.decode(), re.MULTILINE)
+    version = version.group(1) if version else ''
 
     # Make sure Java is 1.7+
     try:


### PR DESCRIPTION
This change fixes the issue surrounding version strings from Java not complying with the assumed syntax. I have made it reasonably flexible in hopes it won't be immediately broken by an untested JDK/JVM instance.

This only changes the way in which the version string is extracted and otherwise leaves your code the same.
