### PR TITLE
Use re.search() when checking java version

### DIFF
--- a/unicycler/misc.py
+++ b/unicycler/misc.py
@@ -997,7 +997,7 @@ def java_version_from_java_output(java_output):
     Parses the Java version from the output of java -version
     Thanks to @cerebis for this code.
     """
-    version = re.match(r'^.* version[ \'"]+([^ \'"]+).*$', java_output, re.MULTILINE)
+    version = re.search(r'^.* version[ \'"]+([^ \'"]+).*$', java_output, re.MULTILINE)
     version = version.group(1) if version else ''
     return version
 


### PR DESCRIPTION
We use `$_JAVA_OPTIONS` to set some global options for all java tools that run under Galaxy, but this causes the first line of java's output to be: `Picked up _JAVA_OPTIONS: -Dfoo ...`, which caused the version check to fail since [re.MULTILINE doesn't work with re.match()](https://docs.python.org/3/library/re.html#re.match), it just happened to work in most cases since in most cases, the first line of stderr was always the version line.