### PR TITLE
Support N-foo style java -version output

### DIFF
--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -372,6 +372,13 @@ class TestMiscFunctions(unittest.TestCase):
         version = unicycler.misc.java_version_from_java_output(java_version_output)
         self.assertEqual(version, '')
 
+    def test_java_version_parsing_6(self):
+        java_version_output = 'openjdk version "9-Ubuntu"\n' \
+                              'OpenJDK Runtime Environment (build 9-Ubuntu+0-9b181-4)\n' \
+                              'OpenJDK 64-Bit Server VM (build 9-Ubuntu+0-9b181-4, mixed mode)'
+        version = unicycler.misc.java_version_from_java_output(java_version_output)
+        self.assertEqual(version, '9-Ubuntu')
+
     def test_spades_version_parsing_1(self):
         spades_version_output = 'SPAdes v3.10.1'
         version = unicycler.misc.spades_version_from_spades_output(spades_version_output)

--- a/unicycler/misc.py
+++ b/unicycler/misc.py
@@ -1059,19 +1059,29 @@ def java_path_and_version(java_path):
 
     # Make sure Java is 1.7+
     try:
-        major_version = int(version.split('.')[0])
-        if major_version < 1:
-            status = 'too old'
-        elif major_version > 1:
-            status = 'good'
-        else:  # major_version == 1
-            minor_version = int(version.split('.')[1])
-            if minor_version < 7:
+        if '.' in version:
+            major_version = int(version.split('.')[0])
+            if major_version < 1:
+                status = 'too old'
+            elif major_version > 1:
+                status = 'good'
+            else:  # major_version == 1
+                minor_version = int(version.split('.')[1])
+                if minor_version < 7:
+                    status = 'too old'
+                else:
+                    status = 'good'
+        elif '-' in version:
+            # E.g. '9-Ubuntu'
+            major_version = int(version.split('-')[0])
+            if major_version < 7:
                 status = 'too old'
             else:
                 status = 'good'
+        else:
+            status = 'bad'
     except (ValueError, IndexError):
-        version, status = '?', 'too old'
+        status = 'bad'
     return found_java_path, version, status
 
 


### PR DESCRIPTION
@EASnavely and I are building a dockerized pipeline of bio tools, one of which is Unicycler. We built an image from an Ubuntu base with openjdk 9. It turns out Ubuntu has a "fun and new" way of reporting the Java version.

This change supports that version format in a simple way. I've added a test which I was able to execute successfully, though I did not run the entire test suite -- is there a recommend instruction set for doing so?