### PR TITLE
unicycler_polish: Add option --no_fix_local

### DIFF
--- a/docs/unicycler-polish.md
+++ b/docs/unicycler-polish.md
@@ -85,6 +85,7 @@ Generic long reads:
 Polishing settings:
   Various settings for polishing behaviour (defaults should work well in most cases)
 
+  --no_fix_local                        do not fix local misassemblies (default: False)
   --min_insert MIN_INSERT               minimum valid short read insert size (default: auto)
   --max_insert MAX_INSERT               maximum valid short read insert size (default: auto)
   --min_align_length MIN_ALIGN_LENGTH   Minimum long read alignment length (default: 1000)

--- a/unicycler/unicycler_polish.py
+++ b/unicycler/unicycler_polish.py
@@ -106,6 +106,8 @@ def get_arguments():
     settings_group = parser.add_argument_group('Polishing settings',
                                                'Various settings for polishing behaviour '
                                                '(defaults should work well in most cases)')
+    settings_group.add_argument('--no_fix_local', action='store_true',
+                                help='do not fix local misassemblies')
     settings_group.add_argument('--min_insert', type=int,
                                 help='minimum valid short read insert size (default: auto)')
     settings_group.add_argument('--max_insert', type=int,
@@ -410,6 +412,11 @@ def pilon_small_changes(fasta, round_num, args, all_ale_scores):
 
 
 def pilon_large_changes(fasta, round_num, args, all_ale_scores):
+    if args.no_fix_local:
+        if args.verbosity > 0:
+            print('Not fixing local misassemblies', flush=True)
+        return fasta, round_num, []
+
     current, round_num, applied_variant = ale_assessed_changes(fasta, round_num, args, True, False,
                                                                all_ale_scores, 'local',
                                                                'Pilon polish, large variants, '


### PR DESCRIPTION
Do not correct local misassemblies with pilon when --no_fix_local is specified.