### PR TITLE
Swap Racon repository URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="misc/logo.png" alt="Unicycler" width="600"></p>
 
-Unicycler is an assembly pipeline for bacterial genomes. It can assemble [Illumina](http://www.illumina.com/)-only read sets where it functions as a [SPAdes](http://cab.spbu.ru/software/spades/)-optimiser. It can also assembly long-read-only sets ([PacBio](http://www.pacb.com/) or [Nanopore](https://nanoporetech.com/)) where it runs a [miniasm](https://github.com/lh3/miniasm)+[Racon](https://github.com/isovic/racon) pipeline. For the best possible assemblies, give it both Illumina reads _and_ long reads, and it will conduct a hybrid assembly.
+Unicycler is an assembly pipeline for bacterial genomes. It can assemble [Illumina](http://www.illumina.com/)-only read sets where it functions as a [SPAdes](http://cab.spbu.ru/software/spades/)-optimiser. It can also assembly long-read-only sets ([PacBio](http://www.pacb.com/) or [Nanopore](https://nanoporetech.com/)) where it runs a [miniasm](https://github.com/lh3/miniasm)+[Racon](https://github.com/lbcb-sci/racon) pipeline. For the best possible assemblies, give it both Illumina reads _and_ long reads, and it will conduct a hybrid assembly.
 
 Read more about Unicycler here:
 > [__Wick RR, Judd LM, Gorrie CL, Holt KE.__ Unicycler: resolving bacterial genome assemblies from short and long sequencing reads. _PLoS Comput Biol_ 2017.](http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1005595)
@@ -107,7 +107,7 @@ Reasons to __not__ use Unicycler:
 * For short-read or hybrid assembly:
   * [SPAdes](http://bioinf.spbau.ru/spades) v3.6.2 – v3.13.0 (`spades.py`)
 * For long-read or hybrid assembly:
-  * [Racon](https://github.com/isovic/racon) (`racon`)
+  * [Racon](https://github.com/lbcb-sci/racon) (`racon`)
 * For polishing
   * [Pilon](https://github.com/broadinstitute/pilon/wiki) (`pilon1.xx.jar`)
   * [Java](https://www.java.com/download/) (`java`)
@@ -285,7 +285,7 @@ The version of miniasm that comes with Unicycler is slightly modified in a coupl
 
 ### Racon polishing
 
-After miniasm assembly, Unicycler carries out multiple rounds of polishing with [Racon](https://github.com/isovic/racon) to improve the sequence accuracy. It will polish until the assembly stops improving, as measured by the agreement between the reads and the assembly. Circular replicons are 'rotated' (have their starting position shifted) between rounds of polishing to ensure that no part of the sequence is left unpolished.
+After miniasm assembly, Unicycler carries out multiple rounds of polishing with [Racon](https://github.com/lbcb-sci/racon) to improve the sequence accuracy. It will polish until the assembly stops improving, as measured by the agreement between the reads and the assembly. Circular replicons are 'rotated' (have their starting position shifted) between rounds of polishing to ensure that no part of the sequence is left unpolished.
 
 
 

--- a/docs/unicycler-polish.md
+++ b/docs/unicycler-polish.md
@@ -11,7 +11,7 @@ It should be considered somewhat experimental, so use with caution!
 * If polishing with PacBio reads: [pbalign](https://github.com/PacificBiosciences/pbalign), [BLASR](https://github.com/PacificBiosciences/blasr), [GenomicConsensus](https://github.com/PacificBiosciences/GenomicConsensus)
     * PacBio software is most easily installed using [pitchfork](https://github.com/PacificBiosciences/pitchfork).
 * If polishing with Illumina and PacBio reads: all of the above dependencies plus [ALE](https://github.com/sc932/ALE).
-* If polishing with both Illumina and long reads (e.g. Nanopore): all of the Illumina polishing dependencies, [Racon](https://github.com/isovic/racon), [FreeBayes](https://github.com/ekg/freebayes) and [ALE](https://github.com/sc932/ALE).
+* If polishing with both Illumina and long reads (e.g. Nanopore): all of the Illumina polishing dependencies, [Racon](https://github.com/lbcb-sci/racon), [FreeBayes](https://github.com/ekg/freebayes) and [ALE](https://github.com/sc932/ALE).
 
 
 ### Process
@@ -22,7 +22,7 @@ Unicycler polish uses an exhaustive iterative process that is time-consuming but
     1. Run [Pilon](https://github.com/broadinstitute/pilon/wiki) in 'bases' mode (substitutions and small indels). If any changes were suggested, apply them and repeat this step.
     2. Run Pilon in 'local' mode (larger variants), and assess each change with ALE. If any variant improves the ALE score, apply it and go back to step 1-i.
 2. If long reads are available:
-    1. Run [GenomicConsensus](https://github.com/PacificBiosciences/GenomicConsensus)/[Racon](https://github.com/isovic/racon) and gather all suggested small changes.
+    1. Run [GenomicConsensus](https://github.com/PacificBiosciences/GenomicConsensus)/[Racon](https://github.com/lbcb-sci/racon) and gather all suggested small changes.
     2. Use [FreeBayes](https://github.com/ekg/freebayes) to assess each long read-suggested change by looking for ambiguity in the Illumina read mapping. If any were found, apply them and go back to step 2-i.
 3. If Illumina reads are available:
     1. Execute step 1 again.


### PR DESCRIPTION
Swaps in the new Racon repository URL (https://github.com/lbcb-sci/racon) for the old Racon repository URL (https://github.com/isovic/racon).

I normally wouldn't submit a PR for a README change, but this one caught me – I installed Racon using its old instructions, which threw me for a loop when it didn't work :)