### PR TITLE
Inherit and use LDFLAGS and CPPFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ CXXFLAGS    ?= -Wall -Wextra -pedantic -mtune=native
 
 # These flags are required for the build to work.
 FLAGS        = -std=c++14 -Iunicycler/include -fPIC
-LDFLAGS      = -shared -lz
+LDFLAGS      += -shared -lz
 
 
 # Platform-specific stuff (for Seqan)
@@ -117,4 +117,4 @@ distclean: clean
 	$(RM) $(TARGET)
 
 %.o: %.cpp $(HEADERS)
-	$(CXX) $(FLAGS) $(CXXFLAGS) -c -o $@ $<
+	$(CXX) $(CPPFLAGS) $(FLAGS) $(CXXFLAGS) -c -o $@ $<


### PR DESCRIPTION
This is a patch we were carrying in the Debian package for Unicycler