### PR TITLE
Leftover Python SyntaxWarnings

### DIFF
--- a/unicycler/bridge_common.py
+++ b/unicycler/bridge_common.py
@@ -40,7 +40,7 @@ def get_bridge_str(bridge):
 
 
 def get_depth_agreement_factor(start_seg_depth, end_seg_depth):
-    """
+    r"""
     This function is set up such that:
       * equal depths return 1.0
       * similar depths return a value near 1.0

--- a/unicycler/bridge_long_read.py
+++ b/unicycler/bridge_long_read.py
@@ -616,7 +616,7 @@ def finalise_bridge(all_args):
 
 
 def reduce_expected_count(expected_count, a, b):
-    """
+    r"""
     This function reduces the expected read count. It reduces by a factor which is a function of
     the read count, so low expected values aren't reduced much, but high expected values are
     reduced more. This is to help with high read depth cases where expected counts get quite high.

--- a/unicycler/log.py
+++ b/unicycler/log.py
@@ -191,4 +191,4 @@ def remove_formatting(text):
 
 
 def remove_dim_formatting(text):
-    return re.sub('\033\[2m', '', text)
+    return re.sub('\033\\[2m', '', text)


### PR DESCRIPTION
While version 0.5.1 fixed several SyntaxWarnings associated to the console logotype, there were still leftover SyntaxWarnings, captured for instance upon Debian package installation:

	Setting up unicycler (0.5.1+dfsg-1) ...
	/usr/lib/python3/dist-packages/unicycler/bridge_common.py:43: SyntaxWarning: invalid escape sequence '\l'
	  """
	/usr/lib/python3/dist-packages/unicycler/bridge_long_read.py:619: SyntaxWarning: invalid escape sequence '\c'
	  """
	/usr/lib/python3/dist-packages/unicycler/log.py:194: SyntaxWarning: invalid escape sequence '\['
	  return re.sub('\033\[2m', '', text)

This change sets the raw string prefix for the two affected docstrings, and also escapes a backaslash in a regex that also includes a legitimate \033 escape sequence.

These issues were initially reported as [Debian bug #1087157].

[Debian bug #1087157]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1087157