### PR TITLE
Fix use of --isolate and --careful options on spades restart

### DIFF
--- a/unicycler/spades_func.py
+++ b/unicycler/spades_func.py
@@ -222,18 +222,18 @@ def build_spades_command(spades_path, spades_dir, threads, kmers, i, short1, sho
     kmer_string = ','.join([str(x) for x in kmers[:i+1]])
 
     command = [spades_path, '-o', spades_dir, '-k', kmer_string, '--threads', str(threads)]
-    split_spade_options = spade_options.split()
+    split_spades_options = spades_options.split()
     if spades_version.startswith("4."):
         command += ['--gfa11']
     if i == 0:  # first k-mer
-        if '--careful' in split_spade_options:
+        if '--careful' in split_spades_options:
             if '--isolate' in split_spades_options:
                 raise ValueError("SPAdes options '--careful' and '--isolate' are not compatible; please choose one or the other")
             command += ['--careful']
-            split_spade_options.remove('--careful')
-        elif '--isolate' in split_spade_options:
+            split_spades_options.remove('--careful')
+        elif '--isolate' in split_spades_options:
             command += ['--isolate']
-            split_spade_options.remove('--isolate')
+            split_spades_options.remove('--isolate')
         if using_paired_reads:
             command += ['-1', short1, '-2', short2]
         if using_unpaired_reads:
@@ -242,8 +242,8 @@ def build_spades_command(spades_path, spades_dir, threads, kmers, i, short1, sho
         previous_k = kmers[i - 1]
         command += ['--restart-from', f'k{previous_k}']
     if spades_options:
-        command += split_spade_options
-    if not spades_options or '-m' not in split_spade_options:
+        command += split_spades_options
+    if not spades_options or '-m' not in split_spades_options:
         command += ['-m', '1024']
     return command
 

--- a/unicycler/spades_func.py
+++ b/unicycler/spades_func.py
@@ -222,15 +222,18 @@ def build_spades_command(spades_path, spades_dir, threads, kmers, i, short1, sho
     kmer_string = ','.join([str(x) for x in kmers[:i+1]])
 
     command = [spades_path, '-o', spades_dir, '-k', kmer_string, '--threads', str(threads)]
+    split_spade_options = spade_options.split()
     if spades_version.startswith("4."):
         command += ['--gfa11']
     if i == 0:  # first k-mer
-        if '--careful' in spades_options.split():
-            if '--isolate' in spades_options.split():
+        if '--careful' in split_spade_options:
+            if '--isolate' in split_spades_options:
                 raise ValueError("SPAdes options '--careful' and '--isolate' are not compatible; please choose one or the other")
             command += ['--careful']
-        elif '--isolate' in spades_options.split():
+            split_spade_options.remove('--careful')
+        elif '--isolate' in split_spade_options:
             command += ['--isolate']
+            split_spade_options.remove('--isolate')
         if using_paired_reads:
             command += ['-1', short1, '-2', short2]
         if using_unpaired_reads:
@@ -239,8 +242,8 @@ def build_spades_command(spades_path, spades_dir, threads, kmers, i, short1, sho
         previous_k = kmers[i - 1]
         command += ['--restart-from', f'k{previous_k}']
     if spades_options:
-        command += spades_options.split()
-    if not spades_options or '-m' not in spades_options.split():
+        command += split_spade_options
+    if not spades_options or '-m' not in split_spade_options:
         command += ['-m', '1024']
     return command
 

--- a/unicycler/spades_func.py
+++ b/unicycler/spades_func.py
@@ -225,7 +225,10 @@ def build_spades_command(spades_path, spades_dir, threads, kmers, i, short1, sho
     if spades_version.startswith("4."):
         command += ['--gfa11']
     if i == 0:  # first k-mer
-        command += ['--isolate']
+        if '--careful' in spades_options.split():
+            command += ['--careful']
+        elif '--isolate' in spades_options.split():
+            command += ['--isolate']
         if using_paired_reads:
             command += ['-1', short1, '-2', short2]
         if using_unpaired_reads:

--- a/unicycler/spades_func.py
+++ b/unicycler/spades_func.py
@@ -226,6 +226,8 @@ def build_spades_command(spades_path, spades_dir, threads, kmers, i, short1, sho
         command += ['--gfa11']
     if i == 0:  # first k-mer
         if '--careful' in spades_options.split():
+            if '--isolate' in spades_options.split():
+                raise ValueError("SPAdes options '--careful' and '--isolate' are not compatible; please choose one or the other")
             command += ['--careful']
         elif '--isolate' in spades_options.split():
             command += ['--isolate']


### PR DESCRIPTION
see https://gitlab.internal.sanger.ac.uk/sanger-pathogens/docker-images/-/merge_requests/471
tests of current main fail when using `--spades_options "--isolate"` with or without other spades options passed on.

while no specific error is raised by `spades.py`, it seems not to like being given the `--isolate` option on the second round of assembly restarting from the precomputed data of first round - a behaviour that would not have happened in the original Unicycler.
```
[fl4@farm22-head2 test_unicycler]$ less mode_bold_spades_options_isolate_/unicycler.log
spades.py -o
```
```
/lustre/scratch126/pam/teams/team230/fl4/test_unicycler/mode_bold_spades_options_isolate_/spades_assembly -k 27 --threads 4 --gfa11 --isolate -1 /lustre/scratch126/p
am/teams/team230/fl4/test_unicycler/SAMN24018632_1.fastq.gz -2 /lustre/scratch126/pam/teams/team230/fl4/test_unicycler/SAMN24018632_2.fastq.gz -m 1024
spades.py -o /lustre/scratch126/pam/teams/team230/fl4/test_unicycler/mode_bold_spades_options_isolate_/spades_assembly -k 27,53 --threads 4 --gfa11 --restart-from k27 --isolate -
m 1024
Error: SPAdes encountered an error:

```
so need to condition the passing of the `--isolate` option to spades being on the first round only.

Question: should we apply this logic to the `--careful` option, while no error was reported with the current behaviour i.e. to pass the option again on 2nd+ round. The risk of not passing it again is that it's not used on those later rounds.
